### PR TITLE
Setup Python 2 on CI for Ubuntu 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # Required because ubuntu-latest (20.04) is missing Python 2
+      # Some dependencies use it https://github.com/actions/virtual-environments/issues/1816
+      - name: Set up Python 2.7.18
+        uses: actions/setup-python@v2
+        with:
+          python-version: 2.7.18
+
       - name: Set up Python 3.8.8
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ jobs:
         with:
           python-version: 2.7.18
 
+      - name: Setup Python 2 pip
+        run: |
+          curl https://bootstrap.pypa.io/get-pip.py --output get-pip.py, python2 get-pip.py
+
       - name: Set up Python 3.8.8
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Setup Python 2 pip
         run: |
-          curl https://bootstrap.pypa.io/get-pip.py --output get-pip.py, python2 get-pip.py
+          curl https://bootstrap.pypa.io/get-pip.py --output get-pip.py && python2 get-pip.py
 
       - name: Set up Python 3.8.8
         uses: actions/setup-python@v2


### PR DESCRIPTION
## What I am changing

This PR adds a step in the GitHub Actions to install Python 2 as I believe this is the reason for the `main` branch failures. I think the switch to Ubuntu 20.04 happened over the weekend for `ubuntu-latest`, which removes Python 2 and it would appear that some dependencies still use Python 2 under the hood 🙃

The following issue outlines this: https://github.com/actions/virtual-environments/issues/1816

## How I did it

* Add `2.7.18` with `actions/setup-python@v2` in `ci.yml`

## How you can test it

By watching this PRs build pass (hopefully) 🤞 