### PR TITLE
Pins CI to Ubuntu 18 and pin Pipfile versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   linting:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
 

--- a/Pipfile
+++ b/Pipfile
@@ -7,9 +7,9 @@ name = "pypi"
 "aws-cdk.core" = "==1.92.0"
 
 [dev-packages]
-black = ">=20.8b1"
-flake8 = ">=3.8.4"
-isort = ">=5.7.0"
+black = "==20.8b1"
+flake8 = "==3.8.4"
+isort = "==5.7.0"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e68bcc5cb083d092208eba283c8ad3b87316d3010766004fe44d0b0529b68491"
+            "sha256": "dd9860dacdd026563b131fecb8af1bfab25a7143c38a2ee84628252e5f7cebb5"
         },
         "pipfile-spec": 6,
         "requires": {


### PR DESCRIPTION
## What I am changing

* Pinning the Ubuntu version on the CI builds to `ubuntu-18.04` as the `20.04` build does not contain Python 2 which appears to be an implicit dependency on some of the packages we install
* Whilst testing this change (to the Ubuntu version) the build still failed
* Pinned our Pipfile dependencies in `[dev]` to stop them being upgraded from what you might have installed locally to what the CI box will install, this seems to have solved it. One of the `[dev]` dependencies seemed to break on updating 🤷 

## How I did it

* Changed `runs-on: ubuntu-latest` to `runs-on: ubuntu-18.04`
* Changed `>=` to `==` in `Pipfile`

## How you can test it

Watch this PR build successfully 🤞 