### PR TITLE
Bucket user

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ RUNNER_TOKEN_SECRET_ARN="<ARN of your Runner Token Secret>" # This is outlined i
 PREFECT__CLOUD__AUTH_TOKEN="<A valid Prefect [Tenant token](https://docs.prefect.io/orchestration/concepts/tokens.html#tenant)> to support flow registration"
 PREFECT_PROJECT="<An existing Prefect [Project](https://docs.prefect.io/orchestration/concepts/projects.html#creating-a-project) where the bakery's test flows will be registered>"
 PREFECT_AGENT_LABELS="<A set of Prefect Agent [Labels](https://docs.prefect.io/orchestration/agents/overview.html#labels) which will be registered with the deployed agent to limit which flows should be executed by the agent>"
+BUCKET_USER_ARN="The manually created user whose credentials will be shared via bakeries.yaml"
 ```
+
 
 An example that you can modify and rename to `.env` is provided: `example.env`
 

--- a/cdk/app.py
+++ b/cdk/app.py
@@ -7,11 +7,13 @@ from bakery_stack import BakeryStack
 app = core.App()
 
 identifier = os.environ["IDENTIFIER"]
+user_arn = os.environ["BUCKET_USER_ARN"]
 
 BakeryStack(
     scope=app,
     construct_id=f"pangeo-forge-aws-bakery-{identifier}",
     identifier=identifier,
+    user_arn=user_arn,
 )
 
 for k, v in {

--- a/cdk/bakery_stack.py
+++ b/cdk/bakery_stack.py
@@ -105,6 +105,24 @@ class BakeryStack(core.Stack):
             )
         )
 
+        bucket.add_to_resource_policy(
+            aws_iam.PolicyStatement(
+                effect=aws_iam.Effect.ALLOW,
+                actions=["s3:*Object"],
+                resources=[f"{bucket.bucket_arn}/*"],
+                principals=[bucket_user],
+            )
+        )
+
+        bucket.add_to_resource_policy(
+            aws_iam.PolicyStatement(
+                effect=aws_iam.Effect.ALLOW,
+                actions=["s3:ListBucket"],
+                resources=[bucket.bucket_arn],
+                principals=[bucket_user],
+            )
+        )
+
         ecs_task_role.add_managed_policy(
             aws_iam.ManagedPolicy.from_aws_managed_policy_name(
                 managed_policy_name="AmazonECS_FullAccess"

--- a/example.env
+++ b/example.env
@@ -7,3 +7,4 @@ PREFECT__CLOUD__AUTH_TOKEN="my-prefect-tenant-token"
 PREFECT_PROJECT="pangeo-forge-aws-bakery"
 PREFECT_AGENT_LABELS='["dask_test"]'
 PYTHONPATH=.
+BUCKET_USER_ARN="Arn of manually created user"


### PR DESCRIPTION
## What I am changing
Adding references for an externally created AWS IAM User whose credentials can be stored in Github Secrets for use by Github Actions in the `staged-recipes` repository when registering flows with Prefect Cloud.

## How I did it
Added an environment variable which can be set with the User Arn and adds permissions for that user to the policies for the flow target and storage buckets.

## How you can test it
Attempt to access the either of the buckets using the created user's credentials.