### PR TITLE
Use pangeo-notebook as a base worker image.

### DIFF
--- a/images/worker/Dockerfile
+++ b/images/worker/Dockerfile
@@ -1,9 +1,7 @@
-FROM python:3.8-buster
-RUN pip install dask-cloudprovider[aws]==2021.3.1
-RUN pip install prefect[aws]==0.14.13
-RUN pip install xarray
-RUN pip install zarr
-RUN pip install s3fs
-RUN pip install git+https://github.com/pangeo-forge/pangeo-forge
-RUN pip install h5py
-RUN pip install h5netcdf
+FROM pangeo/pangeo-notebook:latest
+RUN conda run -n notebook pip install -I git+https://github.com/pangeo-forge/pangeo-forge@master
+RUN conda run -n notebook pip uninstall -y xarray
+RUN conda run -n notebook pip install -I git+https://github.com/pydata/xarray@master
+RUN conda run -n notebook pip install -I dask-cloudprovider==2021.3.1
+RUN conda run -n notebook pip uninstall -y prefect
+RUN conda run -n notebook pip install -I prefect[aws]==0.14.13


### PR DESCRIPTION
## What I am changing
Switching the worker image to use `pangeo-notebook` as a base and using the current `master` branch of `pangeo-forge` (this will be updated as soon as the next version is released). I'm not certain that my approach is the best #22?

## How I did it
Updated the worker's Dockerfile.

## How you can test it
